### PR TITLE
Add support for multiple EventAggregator instances 

### DIFF
--- a/EventAggregator.js
+++ b/EventAggregator.js
@@ -4,8 +4,20 @@ var EventAggregator = function(instanceId) {
 	this.lastSubscriptionId = -1;
 };
 
+EventAggregator.prototype._getCompoundKey = function(key) {
+	return this.instanceId ? this.instanceId + '_' + key : key;
+}
+
+EventAggregator.prototype.setInstanceId = function(instanceId) {
+	this.instanceId = instanceId || '';
+}
+
+EventAggregator.prototype.getInstanceId = function() {
+	return this.instanceId;
+}
+
 EventAggregator.prototype.on = function(key, callback) {
-	var compoundKey = this.instanceId ? this.instanceId + key : key;
+	var compoundKey = this._getCompoundKey(key);	
 	if (typeof callback === "function") {
 		if (!this.eventKeys[compoundKey]) {
 			this.eventKeys[compoundKey] = {
@@ -21,7 +33,7 @@ EventAggregator.prototype.on = function(key, callback) {
 };
 
 EventAggregator.prototype.off = function(key, tokenOrCallback) {
-	var compoundKey = this.instanceId ? this.instanceId + key : key;	
+	var compoundKey = this._getCompoundKey(key);	
 	if (typeof tokenOrCallback === 'function') {
 		//Callback reference was passed in so find the subscription with the matching function
 		if (this.eventKeys[compoundKey]) {
@@ -49,7 +61,7 @@ EventAggregator.prototype.off = function(key, tokenOrCallback) {
 
 EventAggregator.prototype.trigger = function(key) {
 	var self = this;
-	var compoundKey = this.instanceId ? this.instanceId + key : key;		
+	var compoundKey = this._getCompoundKey(key);	
 	if (self.eventKeys[compoundKey]) {
 		var values = Array.prototype.slice.call(arguments, 1);
 		//If passing less than values pass them individually

--- a/EventAggregator.js
+++ b/EventAggregator.js
@@ -1,17 +1,19 @@
-var EventAggregator = function() {
+var EventAggregator = function(instanceId) {
+	this.instanceId = instanceId || '';
 	this.eventKeys = {};
 	this.lastSubscriptionId = -1;
 };
 
 EventAggregator.prototype.on = function(key, callback) {
+	var compoundKey = this.instanceId ? this.instanceId + key : key;
 	if (typeof callback === "function") {
-		if (!this.eventKeys[key]) {
-			this.eventKeys[key] = {
+		if (!this.eventKeys[compoundKey]) {
+			this.eventKeys[compoundKey] = {
 				subscriptions: {}
 			};
 		}
 		var token = (++this.lastSubscriptionId).toString();
-		this.eventKeys[key].subscriptions[token] = callback;
+		this.eventKeys[compoundKey].subscriptions[token] = callback;
 		return token;
 	} else {
 		return false;
@@ -19,10 +21,11 @@ EventAggregator.prototype.on = function(key, callback) {
 };
 
 EventAggregator.prototype.off = function(key, tokenOrCallback) {
+	var compoundKey = this.instanceId ? this.instanceId + key : key;	
 	if (typeof tokenOrCallback === 'function') {
 		//Callback reference was passed in so find the subscription with the matching function
-		if (this.eventKeys[key]) {
-			var eventSubscriptions = this.eventKeys[key].subscriptions;
+		if (this.eventKeys[compoundKey]) {
+			var eventSubscriptions = this.eventKeys[compoundKey].subscriptions;
 			var matchingId = null;
 			//foreach subscription see if the functions match and save the key if yes
 			for (var subscriptionId in eventSubscriptions) {
@@ -38,15 +41,16 @@ EventAggregator.prototype.off = function(key, tokenOrCallback) {
 		}
 	} else {
 		//Token was passed in
-		if (this.eventKeys[key] && this.eventKeys[key].subscriptions[tokenOrCallback]) {
-			delete this.eventKeys[key].subscriptions[tokenOrCallback];
+		if (this.eventKeys[compoundKey] && this.eventKeys[compoundKey].subscriptions[tokenOrCallback]) {
+			delete this.eventKeys[compoundKey].subscriptions[tokenOrCallback];
 		}
 	}
 };
 
 EventAggregator.prototype.trigger = function(key) {
 	var self = this;
-	if (self.eventKeys[key]) {
+	var compoundKey = this.instanceId ? this.instanceId + key : key;		
+	if (self.eventKeys[compoundKey]) {
 		var values = Array.prototype.slice.call(arguments, 1);
 		//If passing less than values pass them individually
 		var a1 = values[0],
@@ -57,7 +61,7 @@ EventAggregator.prototype.trigger = function(key) {
 			a1 = values;
 		}
 
-		var subscriptions = self.eventKeys[key].subscriptions;
+		var subscriptions = self.eventKeys[compoundKey].subscriptions;
 		setTimeout(function() {
 			for (var token in subscriptions) {
 				if (subscriptions.hasOwnProperty(token)) {

--- a/EventAggregator.js
+++ b/EventAggregator.js
@@ -1,19 +1,19 @@
-var EventAggregator = function(instanceId) {
-	this.instanceId = instanceId || '';
+var EventAggregator = function(options) {
+	this.options = options || { instanceId: '' };
 	this.eventKeys = {};
 	this.lastSubscriptionId = -1;
 };
 
 EventAggregator.prototype._getCompoundKey = function(key) {
-	return this.instanceId ? this.instanceId + '_' + key : key;
+	return this.options.instanceId ? this.options.instanceId + '_' + key : key;
 }
 
 EventAggregator.prototype.setInstanceId = function(instanceId) {
-	this.instanceId = instanceId || '';
+	this.options.instanceId = instanceId || '';
 }
 
 EventAggregator.prototype.getInstanceId = function() {
-	return this.instanceId;
+	return this.options.instanceId;
 }
 
 EventAggregator.prototype.on = function(key, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "droopy-events",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Event Aggregator Object",
   "main": "EventAggregator.js",
   "scripts": {


### PR DESCRIPTION
With this addition, you can now pass in an options object with an instanceId to the EventAggregrator constructor. If specified, the events which are registered and triggered will be scoped to only the specified instanceId instead of global to the page.